### PR TITLE
feat: enable trusted publishing for npm package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,6 +41,4 @@ jobs:
         run: pnpm test
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+        run: pnpm publish --provenance --no-git-checks


### PR DESCRIPTION
This pull request updates the `.github/workflows/npm-publish.yml` workflow to improve security and enhance the npm publishing process.

**Security and permissions:**
- Added explicit `permissions` for `contents: read` and `id-token: write` to the workflow, enabling secure authentication for npm provenance publishing.

**Npm publishing improvements:**
- Updated the publish step to use the `--provenance` flag with `pnpm publish`, which enables provenance support for npm packages and removes the use of the `NODE_AUTH_TOKEN` environment variable.